### PR TITLE
Support constants instead of extractors

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,8 @@ fastify.get(
     // enable fastify-casbin-rest plugin on this route, override default "getObj" rule
     casbin: {
       rest: {
-        getObj: request => request.userId
+        getSub: request => request.userId,
+        getAct: 'read'
       },
     }
   },

--- a/README.md
+++ b/README.md
@@ -44,11 +44,11 @@ fastify.route({
 This plugin introduces new route option `casbin.rest`. It can be either a `true` value (which enables default configuration) or an object.
 Supported object options:
 
-| Option   | Type                | Description                      | Default                     |
-| -------- | ------------------- | -------------------------------- | --------------------------- |
-| `getSub` | `Request => string` | Extracts `sub` from the request  | Value from plugin options   |
-| `getObj` | `Request => string` | Extracts `obj` from the request  | Value from plugin options   |
-| `getAct` | `Request => string` | Extracts `act` from the request  | Value from plugin options   |
+| Option   | Type                            | Description                                  | Default                     |
+| -------- | ------------------------------- | -------------------------------------------- | --------------------------- |
+| `getSub` | `Request => string` or `string` | Extracts `sub` from the request or constant  | Value from plugin options   |
+| `getObj` | `Request => string` or `string` | Extracts `obj` from the request or constant  | Value from plugin options   |
+| `getAct` | `Request => string` or `string` | Extracts `act` from the request or constant  | Value from plugin options   |
 
 ### Plugin options
 

--- a/plugin.d.ts
+++ b/plugin.d.ts
@@ -6,9 +6,9 @@ declare module 'fastify' {
   interface RouteShorthandOptions {
     casbin?: {
       rest?: boolean | {
-        getSub?: (request: FastifyRequest) => string,
-        getObj?: (request: FastifyRequest) => string,
-        getAct?: (request: FastifyRequest) => string
+        getSub?: ((request: FastifyRequest) => string) | string,
+        getObj?: ((request: FastifyRequest) => string) | string,
+        getAct?: ((request: FastifyRequest) => string) | string
       }
     }
   }

--- a/plugin.js
+++ b/plugin.js
@@ -30,9 +30,9 @@ async function fastifyCasbinRest (fastify, options) {
         routeOptions[hook] = [routeOptions[hook]]
       }
 
-      const getSub = routeOptions.casbin.rest.getSub || options.getSub
-      const getObj = routeOptions.casbin.rest.getObj || options.getObj
-      const getAct = routeOptions.casbin.rest.getAct || options.getAct
+      const getSub = resolveParameterExtractor(routeOptions.casbin.rest.getSub, options.getSub)
+      const getObj = resolveParameterExtractor(routeOptions.casbin.rest.getObj, options.getObj)
+      const getAct = resolveParameterExtractor(routeOptions.casbin.rest.getAct, options.getAct)
 
       routeOptions[hook].push(async (request, reply) => {
         const sub = getSub(request)
@@ -47,6 +47,20 @@ async function fastifyCasbinRest (fastify, options) {
       })
     }
   })
+}
+
+function isString (value) {
+  return typeof value === 'string'
+}
+
+function resolveParameterExtractor (routeOption, pluginOption) {
+  if (routeOption) {
+    if (isString(routeOption)) {
+      return () => routeOption
+    }
+    return routeOption
+  }
+  return pluginOption
 }
 
 module.exports = fp(fastifyCasbinRest, {

--- a/test/casbinRest.test.js
+++ b/test/casbinRest.test.js
@@ -242,3 +242,41 @@ test('supports overriding plugin rules on route level', t => {
     fastify.close()
   })
 })
+
+test('supports passing constants as extractor params', t => {
+  t.plan(4)
+
+  const fastify = Fastify()
+
+  fastify.register(makeStubCasbin())
+  fastify.register(plugin, {
+    hook: 'onRequest',
+    getSub: request => request.user,
+    getObj: request => request.url,
+    getAct: request => request.method
+  })
+
+  fastify.get('/', {
+    casbin: {
+      rest: {
+        getSub: 'a',
+        getObj: 'b',
+        getAct: 'c'
+      }
+    }
+  }, () => 'ok')
+
+  fastify.ready(async err => {
+    t.error(err)
+
+    fastify.casbin.enforce.callsFake((sub, obj, act) => {
+      t.equal(sub, 'a')
+      t.equal(obj, 'b')
+      t.equal(act, 'c')
+      return Promise.resolve(false)
+    })
+
+    await fastify.inject('/')
+    fastify.close()
+  })
+})

--- a/test/plugin.test-d.ts
+++ b/test/plugin.test-d.ts
@@ -36,3 +36,13 @@ server.get('/', {
     }
   }
 }, () => Promise.resolve('ok'))
+
+server.get('/entity', {
+  casbin: {
+    rest: {
+      getSub: '1',
+      getObj: 'entity',
+      getAct: 'read'
+    }
+  }
+}, () => Promise.resolve('ok'))


### PR DESCRIPTION
Considering that in many cases we know which entity and which operation is the endpoint handling, passing whole function can be redundant.