### PR TITLE
Add support for generics in extractor definition

### DIFF
--- a/plugin.d.ts
+++ b/plugin.d.ts
@@ -1,14 +1,28 @@
 /// <reference types="node" />
 
 import { FastifyInstance, FastifyPluginAsync, FastifyReply, FastifyRequest } from 'fastify'
+import {
+  ContextConfigDefault,
+  RawReplyDefaultExpression,
+  RawRequestDefaultExpression,
+  RawServerBase,
+  RawServerDefault
+} from 'fastify/types/utils'
+import { RouteGenericInterface } from 'fastify/types/route'
 
 declare module 'fastify' {
-  interface RouteShorthandOptions {
+  interface RouteShorthandOptions<
+    RawServer extends RawServerBase = RawServerDefault,
+    RawRequest extends RawRequestDefaultExpression<RawServer> = RawRequestDefaultExpression<RawServer>,
+    RawReply extends RawReplyDefaultExpression<RawServer> = RawReplyDefaultExpression<RawServer>,
+    RouteGeneric extends RouteGenericInterface = RouteGenericInterface,
+    ContextConfig = ContextConfigDefault
+    > {
     casbin?: {
       rest?: boolean | {
-        getSub?: ((request: FastifyRequest) => string) | string,
-        getObj?: ((request: FastifyRequest) => string) | string,
-        getAct?: ((request: FastifyRequest) => string) | string
+        getSub?: ((request: FastifyRequest<RouteGeneric, RawServer, RawRequest>) => string) | string,
+        getObj?: ((request: FastifyRequest<RouteGeneric, RawServer, RawRequest>) => string) | string,
+        getAct?: ((request: FastifyRequest<RouteGeneric, RawServer, RawRequest>) => string) | string
       }
     }
   }

--- a/test/plugin.test-d.ts
+++ b/test/plugin.test-d.ts
@@ -1,4 +1,4 @@
-import fastify, { FastifyReply, FastifyRequest } from 'fastify'
+import fastify, { FastifyReply, FastifyRequest, RequestGenericInterface } from 'fastify'
 import { expectType } from 'tsd'
 import casbinRest from '../plugin'
 
@@ -44,6 +44,21 @@ server.get('/entity', {
       getSub: '1',
       getObj: 'entity',
       getAct: 'read'
+    }
+  }
+}, () => Promise.resolve('ok'))
+
+
+interface ListRequest extends RequestGenericInterface {
+  Params: {
+    listID: string
+  }
+}
+
+server.get<ListRequest>('/', {
+  casbin: {
+    rest: {
+      getObj: (request) => request.params.listID,
     }
   }
 }, () => Promise.resolve('ok'))


### PR DESCRIPTION
Previously generics were ignored inside extractors that made using them in type-safe way a huge hassle.
This makes extractor definitions respect generics specified for the route.