### PR TITLE
Add type test for extended RouteOptions

### DIFF
--- a/test/plugin.test-d.ts
+++ b/test/plugin.test-d.ts
@@ -1,4 +1,5 @@
 import fastify, { FastifyReply, FastifyRequest, RequestGenericInterface } from 'fastify'
+import type { RouteOptions } from 'fastify/types/route'
 import { expectType } from 'tsd'
 import casbinRest from '../plugin'
 
@@ -62,3 +63,18 @@ server.get<ListRequest>('/', {
     }
   }
 }, () => Promise.resolve('ok'))
+
+const route: RouteOptions = {
+  method: 'GET',
+  url: '/',
+  handler: async () => {
+  },
+  casbin: {
+    rest: {
+      getSub: '1',
+      getObj: 'entity',
+      getAct: 'read'
+    }
+  }
+}
+server.route(route)


### PR DESCRIPTION
Add type test to make sure that our way of augmenting route options is compatible with both route definition ways.