### PR TITLE
Add onAllow callback support

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ The API exposed by this plugin is the configuration options:
 | `getObj` | `Request => string`                                        | Extracts `obj` from the request                   | `r => r.url`                    |
 | `getAct` | `Request => string`                                        | Extracts `act` from the request                   | `r => r.method`                 |
 | `onDeny` | `(Reply, { sub, obj, act, dom }) => any`                   | Invoked when Casbin's `enforce` resolves to false | Returns a `403 Forbidden` error |
+| `onAllow`| `(Reply, { sub, obj, act, dom }) => any`                   | Invoked when Casbin's `enforce` resolves to true  | noop                            |
 | `log`    | `(Fastify, Request, { sub, obj, act, dom }) => void`       | Invoked before invoking Casbin's `enforce`        | Logs using fastify.log.info     |
 | `hook`   | `'onRequest', 'preParsing', 'preValidation', 'preHandler'` | Which lifecycle to use for performing the check   | `'preHandler'`                  |
 

--- a/plugin.d.ts
+++ b/plugin.d.ts
@@ -43,6 +43,7 @@ export interface FastifyCasbinRestOptions {
   getObj?(request: FastifyRequest): string
   getAct?(request: FastifyRequest): string
   onDeny?(reply: FastifyReply, checkParams: Permission): void
+  onAllow?(reply: FastifyReply, checkParams: Permission): void
   log?(fastify: FastifyInstance, request: FastifyRequest, checkParams: Permission ): void
   hook?: Hook
 }

--- a/plugin.js
+++ b/plugin.js
@@ -47,7 +47,11 @@ async function fastifyCasbinRest (fastify, options) {
         const isAuthorized = getDom ? await fastify.casbin.enforce(sub, dom, obj, act) : await fastify.casbin.enforce(sub, obj, act)
 
         if (!isAuthorized) {
-          await options.onDeny(reply, { sub, dom, obj, act })
+          return await options.onDeny(reply, { sub, dom, obj, act })
+        }
+
+        if (options.onAllow) {
+          await options.onAllow(reply, { sub, dom, obj, act })
         }
       })
     }

--- a/test/plugin.test-d.ts
+++ b/test/plugin.test-d.ts
@@ -9,6 +9,12 @@ server.register(casbinRest)
 
 server.register(casbinRest, {
   log: (fastify, request, { sub, obj, act }) => { fastify.log.info({ sub, obj, act }, 'Invoking casbin enforce') },
+  onAllow: (reply, { sub, obj, act }) => {
+    expectType<FastifyReply>(reply)
+    expectType<string>(sub)
+    expectType<string>(obj)
+    expectType<string>(act)
+  },
   onDeny: (reply, { sub, obj, act }) => {
     expectType<FastifyReply>(reply)
     expectType<string>(sub)


### PR DESCRIPTION
We intend to use this callback for audit purposes. We already can log failures using onDeny, but successful access is tricky currently.