### PR TITLE
Update fastify-casbin version of the example to 2.1.0

### DIFF
--- a/examples/fastify-casbin-rest-example/package.json
+++ b/examples/fastify-casbin-rest-example/package.json
@@ -13,7 +13,7 @@
     "casbin-pg-adapter": "^1.4.0",
     "casbin-pg-watcher": "^0.1.1",
     "fastify": "^3.7.0",
-    "fastify-casbin": "^1.0.0",
+    "fastify-casbin": "^2.1.0",
     "fastify-cli": "^2.5.0",
     "fastify-jwt": "^2.1.3",
     "fastify-plugin": "^3.0.0",

--- a/examples/fastify-casbin-rest-example/plugins/casbin.js
+++ b/examples/fastify-casbin-rest-example/plugins/casbin.js
@@ -31,7 +31,7 @@ module.exports = fp(async function (
   { connectionString, casbinAdapter }
 ) {
   await fastify.register(require('fastify-casbin'), {
-    modelPath: join(configDir, 'rest_model.conf'),
+    model: join(configDir, 'rest_model.conf'),
     ...(await getCasbinAdapterOptions(casbinAdapter, connectionString))
   })
 


### PR DESCRIPTION
Also, the example needed a fix on the model loader with the update, as the public API also changed.
Closes #54 