### PR TITLE
chore: updates for fastify from 3.29.0 to 4.0.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node: [10, 12, 14, 16]
+        node: [14, 16]
     name: Node ${{ matrix.node }}
     steps:
       - uses: actions/checkout@v3

--- a/examples/fastify-casbin-rest-example/index.js
+++ b/examples/fastify-casbin-rest-example/index.js
@@ -1,7 +1,7 @@
 const { PG_CONNECTION_STRING, CASBIN_ADAPTER, JWT_SECRET } = process.env
 
 module.exports = async function (fastify, opts) {
-  fastify
+  await fastify
     .register(require('fastify-jwt'), {
       secret: JWT_SECRET
     })

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
   },
   "devDependencies": {
     "@types/node": "^17.0.0",
-    "fastify": "^3.10.1",
+    "fastify": "^4.0.2",
     "pre-commit": "^1.2.2",
     "sinon": "^14.0.0",
     "snazzy": "^9.0.0",

--- a/test/casbinRest.test.js
+++ b/test/casbinRest.test.js
@@ -24,340 +24,214 @@ function makeStubCasbin () {
   )
 }
 
-test('throws if no casbin decorator exists', t => {
-  t.plan(1)
+let fastify
 
-  const fastify = Fastify()
-
-  fastify.register(plugin)
-
-  fastify.ready(err => {
-    t.is(err.message, "The decorator 'casbin' required by 'fastify-casbin-rest' is not present in Fastify")
-
-    fastify.close()
-  })
+tap.beforeEach(async () => {
+  fastify = new Fastify()
+  await fastify.register(makeStubCasbin())
 })
 
-test('throws if fastify-casbin plugin is not registered', t => {
-  t.plan(1)
-
-  const fastify = Fastify()
-
-  fastify.decorate('casbin', sinon.stub())
-  fastify.register(plugin)
-
-  fastify.ready(err => {
-    t.is(
-      err.message,
-      "The dependency 'fastify-casbin' of plugin 'fastify-casbin-rest' is not registered"
-    )
-
-    fastify.close()
-  })
+tap.afterEach(async () => {
+  try {
+    await fastify.close()
+  } catch (error) {
+    tap.error(error)
+  }
 })
 
-test('registration succeeds if fastify-casbin providing a casbin decorator exists', t => {
+test('throws if no casbin decorator exists', async t => {
   t.plan(1)
-
-  const fastify = Fastify()
-
-  fastify.register(makeStubCasbin())
-  fastify.register(plugin)
-
-  fastify.ready(err => {
-    t.error(err)
-    fastify.close()
-  })
+  try {
+    const buggyFastify = new Fastify()
+    await buggyFastify.register(plugin)
+  } catch (err) {
+    t.equal(err.message, "The decorator 'casbin' required by 'fastify-casbin-rest' is not present in Fastify")
+  }
 })
 
-test('ignores routes where plugin is not enabled', t => {
-  t.plan(5)
+test('throws if fastify-casbin plugin is not registered', async t => {
+  t.plan(1)
+  try {
+    const buggyFastify = new Fastify()
+    buggyFastify.decorate('casbin', sinon.stub())
+    await buggyFastify.register(plugin)
+  } catch (err) {
+    t.equal(err.message, "The dependency 'fastify-casbin' of plugin 'fastify-casbin-rest' is not registered")
+  }
+})
 
-  const fastify = Fastify()
+test('registration succeeds if fastify-casbin providing a casbin decorator exists', async () => {
+  const workingFastify = new Fastify()
+  await workingFastify.register(makeStubCasbin())
+  await workingFastify.register(plugin)
+  await workingFastify.ready()
+  await workingFastify.close()
+})
 
-  fastify.register(makeStubCasbin())
-  fastify.register(plugin)
+test('ignores routes where plugin is not enabled', async t => {
+  await fastify.register(plugin)
 
   fastify.get('/no-options', () => 'ok')
   fastify.get('/no-casbin-rest', { casbin: {} }, () => 'ok')
   fastify.get('/false-casbin-rest', { casbin: { rest: false } }, () => 'ok')
 
-  fastify.ready(async err => {
-    t.error(err)
+  await fastify.ready()
 
-    t.equal((await fastify.inject('/no-options')).body, 'ok')
-    t.equal((await fastify.inject('/no-casbin-rest')).body, 'ok')
-    t.equal((await fastify.inject('/false-casbin-rest')).body, 'ok')
+  t.equal((await fastify.inject('/no-options')).body, 'ok')
+  t.equal((await fastify.inject('/no-casbin-rest')).body, 'ok')
+  t.equal((await fastify.inject('/false-casbin-rest')).body, 'ok')
 
-    t.false(fastify.casbin.enforce.called)
-
-    fastify.close()
-  })
+  t.notOk(fastify.casbin.enforce.called)
 })
 
-test('allows route where plugin is enabled and enforce resolves true', t => {
-  t.plan(6)
-
-  const fastify = Fastify()
-
-  fastify.register(makeStubCasbin())
-  fastify.register(plugin)
+test('allows route where plugin is enabled and enforce resolves true', async t => {
+  await fastify.register(plugin)
 
   fastify.get('/', { casbin: { rest: true } }, () => 'ok')
 
-  fastify.ready(async err => {
-    t.error(err)
+  fastify.casbin.enforce.resolves(true)
+  await fastify.ready()
 
-    fastify.casbin.enforce.callsFake((sub, obj, act) => {
-      t.equal(sub, undefined)
-      t.equal(obj, '/')
-      t.equal(act, 'GET')
-      return Promise.resolve(true)
-    })
+  t.equal((await fastify.inject('/')).body, 'ok')
+  t.ok(fastify.casbin.enforce.called)
 
-    t.equal((await fastify.inject('/')).body, 'ok')
-
-    t.ok(fastify.casbin.enforce.called)
-
-    fastify.close()
-  })
+  const [sub, obj, act] = fastify.casbin.enforce.getCall(0).args
+  t.equal(sub, undefined)
+  t.equal(obj, '/')
+  t.equal(act, 'GET')
 })
 
-test('allows route where plugin is enabled and enforce resolves true with dom resolver enabled', t => {
-  t.plan(7)
-
-  const fastify = Fastify()
-
-  fastify.register(makeStubCasbin())
-  fastify.register(plugin)
+test('allows route where plugin is enabled and enforce resolves true with dom resolver enabled', async t => {
+  await fastify.register(plugin)
 
   fastify.get('/', { casbin: { rest: { getDom: 'domain' } } }, () => 'ok')
 
-  fastify.ready(async err => {
-    t.error(err)
+  fastify.casbin.enforce.resolves(true)
+  await fastify.ready()
 
-    fastify.casbin.enforce.callsFake((sub, dom, obj, act) => {
-      t.equal(sub, undefined)
-      t.equal(dom, 'domain')
-      t.equal(obj, '/')
-      t.equal(act, 'GET')
-      return Promise.resolve(true)
-    })
+  t.equal((await fastify.inject('/')).body, 'ok')
+  t.ok(fastify.casbin.enforce.called)
 
-    t.equal((await fastify.inject('/')).body, 'ok')
-
-    t.ok(fastify.casbin.enforce.called)
-
-    fastify.close()
-  })
+  const [sub, dom, obj, act] = fastify.casbin.enforce.getCall(0).args
+  t.equal(sub, undefined)
+  t.equal(dom, 'domain')
+  t.equal(obj, '/')
+  t.equal(act, 'GET')
 })
 
-test('invokes onAllow callback if defined', t => {
-  t.plan(9)
-
-  const fastify = Fastify()
-
-  fastify.register(makeStubCasbin())
-  fastify.register(plugin, {
-    onAllow: (reply, { sub, obj, act }) => {
-      t.equal(sub, undefined)
-      t.equal(obj, '/')
-      t.equal(act, 'GET')
-    }
-  })
-
-  fastify.get('/', {
-    casbin: {
-      rest: true
-    }
-  }, () => 'ok')
-
-  fastify.ready(async err => {
-    t.error(err)
-
-    fastify.casbin.enforce.callsFake((sub, obj, act) => {
-      t.equal(sub, undefined)
-      t.equal(obj, '/')
-      t.equal(act, 'GET')
-      return Promise.resolve(true)
-    })
-
-    t.equal((await fastify.inject('/')).body, 'ok')
-
-    t.ok(fastify.casbin.enforce.called)
-
-    fastify.close()
-  })
-})
-
-test('forbids route where plugin is enabled and enforce resolves false', t => {
-  t.plan(6)
-
-  const fastify = Fastify()
-
-  fastify.register(makeStubCasbin())
-  fastify.register(plugin)
+test('invokes onAllow callback if defined', async t => {
+  const onAllow = sinon.spy()
+  await fastify.register(plugin, { onAllow })
 
   fastify.get('/', { casbin: { rest: true } }, () => 'ok')
 
-  fastify.ready(async err => {
-    t.error(err)
+  fastify.casbin.enforce.resolves(true)
+  await fastify.ready()
 
-    fastify.casbin.enforce.callsFake((sub, obj, act) => {
-      t.equal(sub, undefined)
-      t.equal(obj, '/')
-      t.equal(act, 'GET')
-      return Promise.resolve(false)
-    })
+  t.equal((await fastify.inject('/')).body, 'ok')
 
-    t.equal((await fastify.inject('/')).statusCode, 403)
+  t.ok(onAllow.called)
+  const [reply, argsFromCallback] = onAllow.getCall(0).args
+  t.ok(reply)
+  t.equal(argsFromCallback.sub, undefined)
+  t.equal(argsFromCallback.obj, '/')
+  t.equal(argsFromCallback.act, 'GET')
 
-    t.ok(fastify.casbin.enforce.called)
-
-    fastify.close()
-  })
+  t.ok(fastify.casbin.enforce.called)
+  const [sub, obj, act] = fastify.casbin.enforce.getCall(0).args
+  t.equal(sub, undefined)
+  t.equal(obj, '/')
+  t.equal(act, 'GET')
 })
 
-test('forbids route where plugin is enabled and enforce resolves false with dom resolver enabled', t => {
-  t.plan(7)
-
-  const fastify = Fastify()
-
-  fastify.register(makeStubCasbin())
-  fastify.register(plugin, {
-    getDom: () => 'domain'
-  })
+test('forbids route where plugin is enabled and enforce resolves false', async t => {
+  await fastify.register(plugin)
 
   fastify.get('/', { casbin: { rest: true } }, () => 'ok')
 
-  fastify.ready(async err => {
-    t.error(err)
+  fastify.casbin.enforce.resolves(false)
+  await fastify.ready()
 
-    fastify.casbin.enforce.callsFake((sub, dom, obj, act) => {
-      t.equal(sub, undefined)
-      t.equal(dom, 'domain')
-      t.equal(obj, '/')
-      t.equal(act, 'GET')
-      return Promise.resolve(false)
-    })
-
-    const response = await fastify.inject('/')
-    t.equal(response.statusCode, 403)
-
-    t.ok(fastify.casbin.enforce.called)
-
-    fastify.close()
-  })
+  t.equal((await fastify.inject('/')).statusCode, 403)
+  t.ok(fastify.casbin.enforce.called)
 })
 
-test('works correctly if there is an existing preHandler hook', t => {
-  t.plan(4)
+test('forbids route where plugin is enabled and enforce resolves false with dom resolver enabled', async t => {
+  await fastify.register(plugin, { getDom: () => 'domain' })
 
-  let counter = 0
-  const fastify = Fastify()
+  fastify.get('/', { casbin: { rest: true } }, () => 'ok')
 
-  fastify.register(makeStubCasbin())
-  fastify.register(plugin)
+  fastify.casbin.enforce.resolves(false)
+  await fastify.ready()
 
-  fastify.get('/', {
-    preHandler: (req, reply, done) => {
-      counter++
-      done()
-    },
-
-    casbin: { rest: true }
-  }, () => 'ok')
-
-  fastify.ready(async err => {
-    t.error(err)
-
-    fastify.casbin.enforce.resolves(false)
-
-    t.equal((await fastify.inject('/')).statusCode, 403)
-
-    t.ok(fastify.casbin.enforce.called)
-    t.equal(counter, 1)
-
-    fastify.close()
-  })
+  t.equal((await fastify.inject('/')).statusCode, 403)
+  t.ok(fastify.casbin.enforce.called)
 })
 
-test('supports specifying custom hooks', t => {
-  t.plan(4)
+test('works correctly if there is an existing preHandler hook', async t => {
+  await fastify.register(plugin)
 
-  let counter = 0
-  const fastify = Fastify()
+  const preHandler = sinon.spy((req, reply, done) => done())
+  fastify.get('/', { preHandler, casbin: { rest: true } }, () => 'ok')
 
-  fastify.register(makeStubCasbin())
-  fastify.register(plugin, { hook: 'onRequest' })
+  fastify.casbin.enforce.resolves(false)
+  await fastify.ready()
 
-  fastify.get('/', {
-    preParsing: (req, reply, done) => {
-      counter++
-      done()
-    },
-
-    casbin: { rest: true }
-  }, () => 'ok')
-
-  fastify.ready(async err => {
-    t.error(err)
-
-    fastify.casbin.enforce.resolves(false)
-
-    t.equal((await fastify.inject('/')).statusCode, 403)
-
-    t.ok(fastify.casbin.enforce.called)
-    t.equal(counter, 0)
-
-    fastify.close()
-  })
+  t.equal((await fastify.inject('/')).statusCode, 403)
+  t.ok(fastify.casbin.enforce.called)
+  t.ok(preHandler.calledOnce)
 })
 
-test('supports specifying custom logger', t => {
-  t.plan(5)
+test('supports specifying custom hooks', async t => {
+  await fastify.register(plugin, { hook: 'onRequest' })
 
-  const fastify = Fastify()
-  fastify.register(makeStubCasbin())
-  fastify.register(plugin, {
-    log: (fastify, request, { sub, obj, act }) => {
-      t.equal(sub, 'a')
-      t.equal(obj, 'b')
-      t.equal(act, 'c')
-    },
-    getSub: _request => 'a',
-    getObj: _request => 'b',
-    getAct: _request => 'c'
-  })
+  const preParsing = sinon.spy((req, reply, done) => done())
+  fastify.get('/', { preParsing, casbin: { rest: true } }, () => 'ok')
 
-  fastify.get('/', {
-    casbin: { rest: true }
-  }, () => 'ok')
+  fastify.casbin.enforce.resolves(false)
+  await fastify.ready()
 
-  fastify.ready(async err => {
-    t.error(err)
+  t.equal((await fastify.inject('/')).statusCode, 403)
 
-    fastify.casbin.enforce.resolves(true)
-
-    t.equal((await fastify.inject('/')).statusCode, 200)
-
-    fastify.close()
-  })
+  t.ok(fastify.casbin.enforce.called)
+  t.notOk(preParsing.called)
 })
 
-test('supports overriding plugin rules on route level', t => {
-  t.plan(4)
+test('supports specifying custom logger', async t => {
+  const log = sinon.spy()
+  const getSub = sinon.spy((_request) => 'custom sub')
+  const getObj = sinon.spy((_request) => 'custom obj')
+  const getAct = sinon.spy((_request) => 'custom act')
+  await fastify.register(plugin, { log, getSub, getObj, getAct })
 
-  const fastify = Fastify()
+  fastify.get('/', { casbin: { rest: true } }, () => 'ok')
+  fastify.casbin.enforce.resolves(true)
+  await fastify.ready()
 
-  fastify.register(makeStubCasbin())
-  fastify.register(plugin, {
+  t.equal((await fastify.inject('/')).statusCode, 200)
+
+  t.ok(log.called)
+  const [_fastify, _request, argsFromCallback] = log.getCall(0).args
+  t.ok(_fastify)
+  t.ok(_request)
+
+  t.ok(getSub.called)
+  t.equal(argsFromCallback.sub, 'custom sub')
+
+  t.ok(getObj.called)
+  t.equal(argsFromCallback.obj, 'custom obj')
+
+  t.ok(getAct.called)
+  t.equal(argsFromCallback.act, 'custom act')
+})
+
+test('supports overriding plugin rules on route level', async t => {
+  await fastify.register(plugin, {
     hook: 'onRequest',
     getSub: request => request.user,
     getObj: request => request.url,
     getAct: request => request.method
   })
-
   fastify.get('/', {
     casbin: {
       rest: {
@@ -367,35 +241,25 @@ test('supports overriding plugin rules on route level', t => {
       }
     }
   }, () => 'ok')
+  fastify.casbin.enforce.resolves(false)
+  await fastify.ready()
 
-  fastify.ready(async err => {
-    t.error(err)
+  await fastify.inject('/')
 
-    fastify.casbin.enforce.callsFake((sub, obj, act) => {
-      t.equal(sub, 'GET')
-      t.equal(obj, undefined)
-      t.equal(act, '/')
-      return Promise.resolve(false)
-    })
-
-    await fastify.inject('/')
-    fastify.close()
-  })
+  t.ok(fastify.casbin.enforce.called)
+  const [sub, obj, act] = fastify.casbin.enforce.getCall(0).args
+  t.equal(sub, 'GET')
+  t.equal(obj, undefined)
+  t.equal(act, '/')
 })
 
-test('supports passing constants as extractor params without domain', t => {
-  t.plan(4)
-
-  const fastify = Fastify()
-
-  fastify.register(makeStubCasbin())
-  fastify.register(plugin, {
+test('supports passing constants as extractor params without domain', async t => {
+  await fastify.register(plugin, {
     hook: 'onRequest',
     getSub: request => request.user,
     getObj: request => request.url,
     getAct: request => request.method
   })
-
   fastify.get('/', {
     casbin: {
       rest: {
@@ -405,36 +269,26 @@ test('supports passing constants as extractor params without domain', t => {
       }
     }
   }, () => 'ok')
+  fastify.casbin.enforce.resolves(false)
+  await fastify.ready()
 
-  fastify.ready(async err => {
-    t.error(err)
+  await fastify.inject('/')
 
-    fastify.casbin.enforce.callsFake((sub, obj, act) => {
-      t.equal(sub, 'a')
-      t.equal(obj, 'b')
-      t.equal(act, 'c')
-      return Promise.resolve(false)
-    })
-
-    await fastify.inject('/')
-    fastify.close()
-  })
+  t.ok(fastify.casbin.enforce.called)
+  const [sub, obj, act] = fastify.casbin.enforce.getCall(0).args
+  t.equal(sub, 'a')
+  t.equal(obj, 'b')
+  t.equal(act, 'c')
 })
 
-test('supports passing constants as extractor params with domain', t => {
-  t.plan(5)
-
-  const fastify = Fastify()
-
-  fastify.register(makeStubCasbin())
-  fastify.register(plugin, {
+test('supports passing constants as extractor params with domain', async t => {
+  await fastify.register(plugin, {
     hook: 'onRequest',
     getSub: request => request.user,
     getObj: request => request.url,
     getAct: request => request.method,
-    getDom: (request) => 'common'
+    getDom: (_request) => 'common'
   })
-
   fastify.get('/', {
     casbin: {
       rest: {
@@ -445,19 +299,14 @@ test('supports passing constants as extractor params with domain', t => {
       }
     }
   }, () => 'ok')
+  fastify.casbin.enforce.resolves(false)
+  await fastify.ready()
 
-  fastify.ready(async err => {
-    t.error(err)
+  await fastify.inject('/')
 
-    fastify.casbin.enforce.callsFake((sub, dom, obj, act) => {
-      t.equal(sub, 'a')
-      t.equal(dom, 'users')
-      t.equal(obj, 'b')
-      t.equal(act, 'c')
-      return Promise.resolve(false)
-    })
-
-    await fastify.inject('/')
-    fastify.close()
-  })
+  const [sub, dom, obj, act] = fastify.casbin.enforce.getCall(0).args
+  t.equal(sub, 'a')
+  t.equal(dom, 'users')
+  t.equal(obj, 'b')
+  t.equal(act, 'c')
 })


### PR DESCRIPTION
resolves https://github.com/nearform/fastify-casbin-rest/issues/75

- update fastify to its 4.0.2 version (from https://github.com/nearform/fastify-casbin-rest/pull/72)
- remove node 10 and 12 from CI (not supported anymore by fastify 4)
- reflect latests changes on breaking tests -- based on https://medium.com/@fastifyjs/fastify-v4-ga-59f2103b5f0e 
- taking the chance to improve tests quality with "idiomatic" changes, better using tap and sinon
