### PR TITLE
chore(deps): consolidate dependabot dependency bumps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,9 +14,9 @@ jobs:
           - 22
     name: Node ${{ matrix.node }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Setup node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: ${{ matrix.node }}
       - run: npm install

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "plugin.js",
   "types": "plugin.d.ts",
   "scripts": {
-    "test": "node --test \"test/*.test.js\" && npm run typescript",
+    "test": "node --test test/*.test.js && npm run typescript",
     "lint": "standard | snazzy",
     "lint:fix": "standard --fix | snazzy",
     "typescript": "tsd"

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "plugin.js",
   "types": "plugin.d.ts",
   "scripts": {
-    "test": "node --test && npm run typescript",
+    "test": "node --test \"test/*.test.js\" && npm run typescript",
     "lint": "standard | snazzy",
     "lint:fix": "standard --fix | snazzy",
     "typescript": "tsd"
@@ -44,13 +44,13 @@
     "http-errors": "^2.0.0"
   },
   "devDependencies": {
-    "@types/node": "^22.10.1",
+    "@types/node": "^25.2.0",
     "fastify": "^5.1.0",
     "pre-commit": "^1.2.2",
-    "sinon": "^19.0.2",
+    "sinon": "^21.0.1",
     "snazzy": "^9.0.0",
     "standard": "^17.1.2",
-    "tsd": "^0.31.2",
+    "tsd": "^0.33.0",
     "typescript": "^5.7.2"
   }
 }


### PR DESCRIPTION
Closes #168

## Summary

Consolidates all open Dependabot pull requests into a single change so the dependency bumps can be reviewed, verified, and merged together.

| Dependency | From | To | Supersedes |
| --- | --- | --- | --- |
| `@types/node` | `^22.10.1` | `^25.2.0` | #165 |
| `sinon` | `^19.0.2` | `^21.0.1` | #160 |
| `tsd` | `^0.31.2` | `^0.33.0` | #156 |
| `actions/checkout` | `v4` | `v6` | #157 |
| `actions/setup-node` | `v4` | `v6` | #153 |
| `fastify` | `v4` | `v5` | #147 (already on `master`, no-op) |

## Guarding against breakage

The repo already ships a comprehensive unit-test suite (`test/casbinRest.test.js`, 15 tests) plus `tsd` type tests (`test/plugin.test-d.ts`). Both pass against every bumped version on the CI Node matrix (20 and 22).

While verifying, refreshing the CI actions to their latest node minors surfaced a **latent break**: Node 22.18+ enables TypeScript type-stripping by default, so `node --test` began discovering the `tsd` type-declaration file (`plugin.test-d.ts`) and executing it as a real test — failing on its extensionless ESM import. Fixed by scoping the runner to the shell-expanded `test/*.test.js` glob (kept unquoted so Node 20, which lacks native glob support in the test runner, works too). `tsd` still type-checks the declaration file via `npm run typescript`.

## Verification

- `npm run lint` ✅
- `npm test` — 15/15 unit tests ✅ + `tsd` ✅
- CI: Node 20 ✅, Node 22 ✅

## Follow-up

The 6 superseded Dependabot PRs (#165, #160, #157, #156, #153, #147) are closed in favour of this consolidated PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)